### PR TITLE
Broken Images/Tests on Gold Patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## SWE-bench Fork for Running SWE-rebench
+ ## SWE-bench Fork for Running SWE-rebench
 
 This fork of SWE-bench includes updates necessary for running SWE-rebench files.
 


### PR DESCRIPTION
Sorry, issues are not enabled so I take the unconventional way.

I noticed that at least one image got broken with the latest batch of updates. swerebench/sweb.eval.x86_64.pennylaneai_1776_pennylane-7671 worked with the image from 13 days ago, using the one from 3 days ago failed due to dependency issues

I noticed other failed instances when running with gold patch:
```
    "total_instances": 693,
    "submitted_instances": 693,
    "completed_instances": 688,
    "resolved_instances": 631,
    "unresolved_instances": 57,
    "empty_patch_instances": 0,
    "error_instances": 5,
```